### PR TITLE
Minor fixes from testing on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/nbproject/

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,26 @@
 CPP=g++
 CPPFLAGS=-O2
 
-LIB_PROFILER=libasyncProfiler.so
-INCLUDES=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
-
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	LIB_PROFILER=libasyncProfiler.so
+	INCLUDES=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+endif
+ifeq ($(UNAME_S),Darwin)
+	LIB_PROFILER=libasyncProfiler.dylib
+	INCLUDES=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin
+endif
 
 all: build build/$(LIB_PROFILER)
 
 build:
 	mkdir -p build
 
-build/$(LIB_PROFILER): src/*.cpp src/*.h
+build/libasyncProfiler.so: src/*.cpp src/*.h
 	$(CPP) $(CPPFLAGS) $(INCLUDES) -fPIC -shared -o $@ -Wl,-soname,$(LIB_PROFILER) $^
+
+build/libasyncProfiler.dylib: src/*.cpp src/*.h
+	$(CPP) $(CPPFLAGS) $(INCLUDES) -fPIC -shared -o $@ -Wl,-install_name,$(LIB_PROFILER) src/*.cpp
 
 clean:
 	rm -rf build

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -157,6 +157,7 @@ void Profiler::recordSample(void* ucontext) {
     if (trace.num_frames > 0) {
         storeCallTrace(&trace);
         storeMethod(frames[0].method_id);
+    // See ticks_* enum values in http://hg.openjdk.java.net/jdk8/jdk8/hotspot/file/tip/src/share/vm/prims/forte.cpp
     } else if (trace.num_frames == 0) {
         _calls_non_java++;
     } else if (trace.num_frames == -1) {

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -189,7 +189,7 @@ void Profiler::start(long interval) {
     memset(_traces, 0, sizeof(_traces));
     memset(_methods, 0, sizeof(_methods));
 
-    setTimer(interval / 1000, interval * 1000);
+    setTimer(interval / 1000, (interval % 1000) * 1000);
 }
 
 void Profiler::stop() {

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -234,14 +234,14 @@ void Profiler::dumpTraces(std::ostream& out, int max_traces) {
         int samples = _traces[i]._call_count;
         if (samples == 0) break;
 
-        sprintf(buf, "Samples: %d (%.2f%%)\n", samples, samples * percent);
+        snprintf(buf, sizeof(buf), "Samples: %d (%.2f%%)\n", samples, samples * percent);
         out << buf;
 
         for (int j = 0; j < _traces[i]._num_frames; j++) {
             ASGCT_CallFrame* frame = &_traces[i]._frames[j];
             if (frame->method_id != NULL) {
                 MethodName mn(frame->method_id);
-                sprintf(buf, "  [%2d] %s.%s @%d\n", j, mn.holder(), mn.name(), frame->bci);
+                snprintf(buf, sizeof(buf), "  [%2d] %s.%s @%d\n", j, mn.holder(), mn.name(), frame->bci);
                 out << buf;
             }
         }
@@ -262,7 +262,7 @@ void Profiler::dumpMethods(std::ostream& out) {
         if (samples == 0) break;
 
         MethodName mn(_methods[i]._method);
-        sprintf(buf, "%6d (%.2f%%) %s.%s\n", samples, samples * percent, mn.holder(), mn.name());
+        snprintf(buf, sizeof(buf), "%6d (%.2f%%) %s.%s\n", samples, samples * percent, mn.holder(), mn.name());
         out << buf;
     }
 }

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -174,10 +174,12 @@ void Profiler::setTimer(long sec, long usec) {
     sa.sa_sigaction = enabled ? sigprofHandler : NULL;
     sa.sa_flags = SA_RESTART | SA_SIGINFO;
     sigemptyset(&sa.sa_mask);
-    sigaction(SIGPROF, &sa, NULL);
+    if (sigaction(SIGPROF, &sa, NULL) != 0)
+        perror("couldn't install signal handler");
 
     struct itimerval itv = {{sec, usec}, {sec, usec}};
-    setitimer(ITIMER_PROF, &itv, NULL);
+    if (setitimer(ITIMER_PROF, &itv, NULL) != 0)
+        perror("couldn't start timer");
 }
 
 void Profiler::start(long interval) {

--- a/src/asyncProfiler.h
+++ b/src/asyncProfiler.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <dlfcn.h>
 #include <jvmti.h>
 #include <iostream>
 
@@ -37,6 +38,9 @@ typedef struct {
     ASGCT_CallFrame* frames;
 } ASGCT_CallTrace;
 
+typedef void (*ASGCTType)(ASGCT_CallTrace *, jint, void *);
+
+extern "C" ASGCTType asgct;
 
 class MethodName {
   private:
@@ -115,7 +119,3 @@ class Profiler {
     void dumpMethods(std::ostream& out);
     void recordSample(void* ucontext);
 };
-
-
-extern "C" JNIIMPORT void JNICALL
-AsyncGetCallTrace(ASGCT_CallTrace* trace, jint depth, void* ucontext);

--- a/src/asyncProfiler.h
+++ b/src/asyncProfiler.h
@@ -90,9 +90,18 @@ class Profiler {
   private:
     bool _running;
     int _calls_total;
+    // See ./hotspot/src/share/vm/prims/forte.cpp
     int _calls_non_java;
-    int _calls_gc;
+    int _calls_no_class_load;
+    int _calls_gc_active;
+    int _calls_unknown_not_java;
+    int _calls_not_walkable_not_java;
+    int _calls_unknown_java;
+    int _calls_not_walkable_java;
+    int _calls_unknown_state;
+    int _calls_thread_exit;
     int _calls_deopt;
+    int _calls_safepoint;
     int _calls_unknown;
     u64 _hashes[MAX_CALLTRACES];
     CallTraceSample _traces[MAX_CALLTRACES];

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -21,28 +21,10 @@
 JavaVM* VM::_vm;
 jvmtiEnv* VM::_jvmti;
 
-
-// Short version: reinterpret_cast produces undefined behavior in many
-// cases where memcpy doesn't.
-
-template<class Dest, class Source>
-inline Dest bit_cast(const Source &source) {
-    // Compile time assertion: sizeof(Dest) == sizeof(Source)
-    // A compile error here means your Dest and Source have different sizes.
-    typedef char VerifySizesAreEqual[sizeof (Dest) == sizeof (Source) ? 1 : -1]
-            __attribute__((unused));
-
-    Dest dest;
-    memcpy(&dest, &source, sizeof (dest));
-    return dest;
-}
-
-// Accessors for getting the JVM function for AsyncGetCallTrace
-
 template<class FunctionType>
 inline FunctionType getJvmFunction(const char *function_name) {
     // get address of function, return null if not found
-    return bit_cast<FunctionType>(dlsym(RTLD_DEFAULT, function_name));
+    return (FunctionType) dlsym(RTLD_DEFAULT, function_name);
 }
 
 void VM::init(JavaVM* vm) {


### PR DESCRIPTION
* Ignoring `nbproject`
* Support for darwin compilation
* Using `dlsym()` to load `AsyncGetCallTrace` from JVM
* Fixed timer parameters
* Processing return codes of system calls
* Using `snprintf()` instead of `sprintf()`
* Counting distinct frame errors