### PR TITLE
Support for flame graph building

### DIFF
--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -25,6 +25,7 @@
 #include "vmEntry.h"
 
 ASGCTType asgct;
+int maxFrames = DEFAULT_MAX_FRAMES;
 Profiler Profiler::_instance;
 
 static void sigprofHandler(int signo, siginfo_t* siginfo, void* ucontext) {
@@ -56,7 +57,7 @@ MethodName::~MethodName() {
 
 void CallTraceSample::assign(ASGCT_CallTrace* trace) {
     _call_count = 1;
-    _num_frames = MIN(trace->num_frames, MAX_FRAMES);
+    _num_frames = MIN(trace->num_frames, maxFrames);
     
     const int offset = trace->num_frames - _num_frames;    
     for (int i = 0; i < _num_frames; i++) {
@@ -221,7 +222,13 @@ void Profiler::start(long interval) {
     _calls_safepoint = 0;
     _calls_unknown = 0;
     memset(_hashes, 0, sizeof(_hashes));
+    for (int i = 0; i < MAX_CALLTRACES; i++) {
+        free(_traces[i]._frames);
+        _traces[i]._frames = NULL;
+    }
     memset(_traces, 0, sizeof(_traces));
+    for (int i = 0; i < MAX_CALLTRACES; i++)
+        _traces[i]._frames = (ASGCT_CallFrame *) malloc(maxFrames * sizeof(ASGCT_CallFrame));
     memset(_methods, 0, sizeof(_methods));
 
     setTimer(interval / 1000, (interval % 1000) * 1000);

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -25,7 +25,6 @@
 #include "vmEntry.h"
 
 ASGCTType asgct;
-int maxFrames = DEFAULT_MAX_FRAMES;
 Profiler Profiler::_instance;
 
 static void sigprofHandler(int signo, siginfo_t* siginfo, void* ucontext) {
@@ -54,17 +53,13 @@ MethodName::~MethodName() {
     jvmti->Deallocate((unsigned char*)_class_sig);
 }
 
-
-void CallTraceSample::assign(ASGCT_CallTrace* trace) {
-    _call_count = 1;
-    _num_frames = MIN(trace->num_frames, maxFrames);
-    
-    const int offset = trace->num_frames - _num_frames;    
-    for (int i = 0; i < _num_frames; i++) {
-        _frames[i] = trace->frames[offset + i];
+void Profiler::frameBufferSize(int size) {
+    if (size >= 0) {
+        _frameBufferSize = size;
+    } else {
+        std::cerr << "Ignoring frame buffer size " << size << std::endl;
     }
 }
-
 
 u64 Profiler::hashCallTrace(ASGCT_CallTrace* trace) {
     const u64 M = 0xc6a4a7935bd1e995LL;
@@ -102,9 +97,24 @@ void Profiler::storeCallTrace(ASGCT_CallTrace* trace) {
         }
         if (++i == MAX_CALLTRACES) i = 0;
     } while (i != bucket);
+    
+    if (_frameBufferSize - _freeFrame < trace->num_frames) {
+        // Don't have enough space to store call trace
+        _frameBufferOverflow = true;
+        return;
+    }
 
     _hashes[i] = hash;
-    _traces[i].assign(trace);
+    
+    _traces[i]._call_count = 1;
+    _traces[i]._offset = _freeFrame;
+    _traces[i]._num_frames = trace->num_frames;
+
+    // Copying frames into frame buffer
+    for (int i = 0; i < trace->num_frames; i++) {
+        _frames[_freeFrame] = trace->frames[i];
+        _freeFrame++;
+    }
 }
 
 u64 Profiler::hashMethod(jmethodID method) {
@@ -222,14 +232,14 @@ void Profiler::start(long interval) {
     _calls_safepoint = 0;
     _calls_unknown = 0;
     memset(_hashes, 0, sizeof(_hashes));
-    for (int i = 0; i < MAX_CALLTRACES; i++) {
-        free(_traces[i]._frames);
-        _traces[i]._frames = NULL;
-    }
     memset(_traces, 0, sizeof(_traces));
-    for (int i = 0; i < MAX_CALLTRACES; i++)
-        _traces[i]._frames = (ASGCT_CallFrame *) malloc(maxFrames * sizeof(ASGCT_CallFrame));
     memset(_methods, 0, sizeof(_methods));
+    
+    // Reset frames
+    free(_frames);
+    _frames = (ASGCT_CallFrame *) malloc(_frameBufferSize * sizeof (ASGCT_CallFrame));
+    _freeFrame = 0;
+    _frameBufferOverflow = false;
 
     setTimer(interval / 1000, (interval % 1000) * 1000);
 }
@@ -239,6 +249,16 @@ void Profiler::stop() {
     _running = false;
 
     setTimer(0, 0);
+    
+    if (_frameBufferOverflow) {
+        std::cerr << "Frame buffer overflowed with size " << _frameBufferSize 
+                << ". Consider increasing its size." << std::endl;
+    } else {
+        std::cout << "Frame buffer usage " 
+                << _freeFrame << "/" << _frameBufferSize 
+                << "=" 
+                << 100.0 * _freeFrame / _frameBufferSize << "%" << std::endl;
+    }
 }
 
 void nonzero_summary(std::ostream& out, const char* fmt, int calls, float percent) {
@@ -317,8 +337,9 @@ void Profiler::dumpRawTraces(std::ostream& out) {
         
         out << samples << '\t' << _traces[i]._num_frames << '\t';
 
-        for (int j = 0; j < _traces[i]._num_frames; j++) {
-            ASGCT_CallFrame* frame = &_traces[i]._frames[j];
+        CallTraceSample& trace = _traces[i];
+        for (int j = 0; j < trace._num_frames; j++) {
+            ASGCT_CallFrame* frame = &_frames[trace._offset + j];
             if (frame->method_id != NULL) {
                 if (j != 0) {
                     out << "\t\t";
@@ -347,8 +368,9 @@ void Profiler::dumpTraces(std::ostream& out, int max_traces) {
         snprintf(buf, sizeof(buf), "Samples: %d (%.2f%%)\n", samples, samples * percent);
         out << buf;
 
-        for (int j = 0; j < _traces[i]._num_frames; j++) {
-            ASGCT_CallFrame* frame = &_traces[i]._frames[j];
+        CallTraceSample& trace = _traces[i];
+        for (int j = 0; j < trace._num_frames; j++) {
+            ASGCT_CallFrame* frame = &_frames[trace._offset + j];
             if (frame->method_id != NULL) {
                 MethodName mn(frame->method_id);
                 snprintf(buf, sizeof(buf), "  [%2d] %s.%s @%d\n", j, mn.holder(), mn.name(), frame->bci);

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -289,6 +289,37 @@ void Profiler::summary(std::ostream& out) {
     out << std::endl;
 }
 
+/*
+ * Dumping in lightweight-java-profiler format:
+ * 
+ * <samples> <frames>   <frame1>
+ *                      <frame2>
+ *                      ...
+ *                      <framen>
+ */
+void Profiler::dumpRawTraces(std::ostream& out) {
+    if (_running) return;
+
+    for (int i = 0; i < MAX_CALLTRACES; i++) {
+        const int samples = _traces[i]._call_count;
+        if (samples == 0) continue;
+        
+        out << samples << '\t' << _traces[i]._num_frames << '\t';
+
+        for (int j = 0; j < _traces[i]._num_frames; j++) {
+            ASGCT_CallFrame* frame = &_traces[i]._frames[j];
+            if (frame->method_id != NULL) {
+                if (j != 0) {
+                    out << "\t\t";
+                }
+
+                MethodName mn(frame->method_id);
+                out << mn.holder() << "::" << mn.name() << std::endl;
+            }
+        }
+    }
+}
+
 void Profiler::dumpTraces(std::ostream& out, int max_traces) {
     if (_running) return;
 

--- a/src/asyncProfiler.h
+++ b/src/asyncProfiler.h
@@ -18,9 +18,9 @@
 #include <jvmti.h>
 #include <iostream>
 
-#define MAX_FRAMES     64
 #define MAX_CALLTRACES 32768
 
+#define DEFAULT_MAX_FRAMES     64
 #define DEFAULT_INTERVAL       10
 #define DEFAULT_TRACES_TO_DUMP 500
 
@@ -57,15 +57,19 @@ class MethodName {
     char* signature() { return _sig; }
 };
 
+extern "C" int maxFrames;
+
 class CallTraceSample {
   private:
     int _call_count;
     int _num_frames;
-    ASGCT_CallFrame _frames[MAX_FRAMES];
+    ASGCT_CallFrame *_frames;
 
     void assign(ASGCT_CallTrace* trace);
 
   public:
+    CallTraceSample(): _frames(NULL) {}
+      
     static int comparator(const void* s1, const void* s2) {
         return ((CallTraceSample*)s2)->_call_count - ((CallTraceSample*)s1)->_call_count;
     }

--- a/src/asyncProfiler.h
+++ b/src/asyncProfiler.h
@@ -105,7 +105,7 @@ class Profiler {
     CallTraceSample _traces[MAX_CALLTRACES];
     MethodSample _methods[MAX_CALLTRACES];
     
-    ASGCT_CallFrame *_frames;
+    jmethodID *_frames;
     int _frameBufferSize;
     int _freeFrame;
     bool _frameBufferOverflow;

--- a/src/asyncProfiler.h
+++ b/src/asyncProfiler.h
@@ -124,6 +124,7 @@ class Profiler {
     void start(long interval);
     void stop();
     void summary(std::ostream& out);
+    void dumpRawTraces(std::ostream& out);
     void dumpTraces(std::ostream& out, int max_traces);
     void dumpMethods(std::ostream& out);
     void recordSample(void* ucontext);

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -93,8 +93,15 @@ const char DUMP_RAW_TRACES[] = "dumpRawTraces:";
 extern "C" JNIEXPORT jint JNICALL
 Agent_OnAttach(JavaVM* vm, char* options, void* reserved) {
     VM::attach(vm);
-
-    char *token = strtok(options, OPTION_DELIMITER);
+    
+    char args[1024];
+    if (strlen(options) >= sizeof(args)) {
+        std::cerr << "List of options is too long" << std::endl;
+        return -1;
+    }
+    strncpy(args, options, sizeof(args));
+    
+    char *token = strtok(args, OPTION_DELIMITER);
     while (token) {
         if (strncmp(token, FRAME_BUFFER_SIZE, strlen(FRAME_BUFFER_SIZE)) == 0) {
             const char *text = token + strlen(FRAME_BUFFER_SIZE);

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -53,6 +53,8 @@ void VM::init(JavaVM* vm) {
     _jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL);
     _jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL);
     _jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL);
+
+    asgct = getJvmFunction<ASGCTType>("AsyncGetCallTrace");
 }
 
 void VM::loadMethodIDs(jvmtiEnv* jvmti, jclass klass) {
@@ -78,7 +80,6 @@ void VM::loadAllMethodIDs(jvmtiEnv* jvmti) {
 extern "C" JNIEXPORT jint JNICALL
 Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
     VM::init(vm);
-    asgct = getJvmFunction<ASGCTType>("AsyncGetCallTrace");
     Profiler::_instance.start(DEFAULT_INTERVAL);
     return 0;
 }
@@ -92,7 +93,6 @@ const char DUMP_RAW_TRACES[] = "dumpRawTraces:";
 extern "C" JNIEXPORT jint JNICALL
 Agent_OnAttach(JavaVM* vm, char* options, void* reserved) {
     VM::attach(vm);
-    asgct = getJvmFunction<ASGCTType>("AsyncGetCallTrace");
 
     char *token = strtok(options, OPTION_DELIMITER);
     while (token) {
@@ -135,6 +135,5 @@ Agent_OnAttach(JavaVM* vm, char* options, void* reserved) {
 extern "C" JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM* vm, void* reserved) {
     VM::attach(vm);
-    asgct = getJvmFunction<ASGCTType>("AsyncGetCallTrace");
     return JNI_VERSION_1_6;
 }

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -16,6 +16,7 @@
 
 #include <fstream>
 #include <string.h>
+#include <stdlib.h>
 #include "asyncProfiler.h"
 #include "vmEntry.h"
 
@@ -83,7 +84,7 @@ Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
 }
 
 const char OPTION_DELIMITER[] = ",";
-const char MAX_FRAMES[] = "maxFrames:";
+const char FRAME_BUFFER_SIZE[] = "frameBufferSize:";
 const char START[] = "start";
 const char STOP[] = "stop";
 const char DUMP_RAW_TRACES[] = "dumpRawTraces:";
@@ -95,15 +96,11 @@ Agent_OnAttach(JavaVM* vm, char* options, void* reserved) {
 
     char *token = strtok(options, OPTION_DELIMITER);
     while (token) {
-        if (strncmp(token, MAX_FRAMES, strlen(MAX_FRAMES)) == 0) {
-            const char *text = token + strlen(MAX_FRAMES);
+        if (strncmp(token, FRAME_BUFFER_SIZE, strlen(FRAME_BUFFER_SIZE)) == 0) {
+            const char *text = token + strlen(FRAME_BUFFER_SIZE);
             const int value = atoi(text);
-            if (value >= 0) {
-                std::cout << "Setting max frames to " << value << std::endl;
-                maxFrames = value;
-            } else {
-                std::cout << "Ignoring max frames value " << value << std::endl;
-            }
+            std::cout << "Setting frame buffer size to " << value << std::endl;
+            Profiler::_instance.frameBufferSize(value);
         } else if (strcmp(token, START) == 0) {
             std::cout << "Profiling started" << std::endl;
             Profiler::_instance.start(DEFAULT_INTERVAL);

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -84,6 +84,7 @@ Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
 extern "C" JNIEXPORT jint JNICALL
 Agent_OnAttach(JavaVM* vm, char* options, void* reserved) {
     VM::attach(vm);
+    asgct = getJvmFunction<ASGCTType>("AsyncGetCallTrace");
 
     if (strcmp(options, "start") == 0) {
         std::cout << "Profiling started\n";

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fstream>
 #include <string.h>
 #include "asyncProfiler.h"
 #include "vmEntry.h"
@@ -81,6 +82,8 @@ Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
     return 0;
 }
 
+const char DUMP_RAW_TRACES[] = "dumpRawTraces:";
+
 extern "C" JNIEXPORT jint JNICALL
 Agent_OnAttach(JavaVM* vm, char* options, void* reserved) {
     VM::attach(vm);
@@ -94,6 +97,21 @@ Agent_OnAttach(JavaVM* vm, char* options, void* reserved) {
         Profiler::_instance.stop();
         Profiler::_instance.dumpTraces(std::cout, DEFAULT_TRACES_TO_DUMP);
         Profiler::_instance.dumpMethods(std::cout);
+    } else if (strstr(options, DUMP_RAW_TRACES) != NULL) {
+        std::cout << "Profiling stopped\n";
+        Profiler::_instance.stop();
+
+        const char *fileName = options + strlen(DUMP_RAW_TRACES);
+
+        std::ofstream dump(fileName, std::ios::out | std::ios::trunc);
+        if (!dump.is_open()) {
+            std::cerr << "Couldn't open: " << fileName << std::endl;
+            return -1;
+        }
+        
+        std::cout << "Dumping raw traces to " << fileName << std::endl;
+        Profiler::_instance.dumpRawTraces(dump);
+        dump.close();
     }
 
     return 0;


### PR DESCRIPTION
Now you can dynamically attach `async-profiler` and pass it the following options:
1. `frameBufferSize:<size>` to set the size of the frame buffer
2. `start` to start profiling
3. `stop` to stop profiling
4. `dumpRawTraces:<file>` to dump collected stack traces into `<file>` in `lightweight-java-profiler` format

Then you can process the stack traces and build flame graphs:
```sh
echo "Collapsing stacks into ${STACKS}..."
cat $RAW | ${FLAMEGRAPH_DIR}/stackcollapse-ljp.awk >$STACKS
echo "Collapsing recursion into ${NON_RECURSIVE}..."
cat $STACKS | sort | ${FLAMEGRAPH_DIR}/stackcollapse-recursive.pl >$NON_RECURSIVE
echo "Building SVG into ${SVG}..."
cat $NON_RECURSIVE | ${FLAMEGRAPH_DIR}/flamegraph.pl >$SVG
```

Changes:
  * `Agent_OnAttach` resolves `AsyncGetCallTrace` each time to support dynamic attach
  * Dumping collected traces in `lightweight-java-profiler` format to be able to build flame graphs
  * For the history (to be able to revert to legacy behavior):
    * Properly stripping frames if the trace is too long
    * Dynamically tuneable stack trace depth
  * Replaced preallocated frames with shared frame buffer
  * Ignoring `bci` when storing frames