### PR TITLE
Initialise JVMTI once and forever

### DIFF
--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -21,7 +21,7 @@
 #include "vmEntry.h"
 
 JavaVM* VM::_vm;
-jvmtiEnv* VM::_jvmti;
+jvmtiEnv* VM::_jvmti = NULL;
 
 template<class FunctionType>
 inline FunctionType getJvmFunction(const char *function_name) {
@@ -31,7 +31,9 @@ inline FunctionType getJvmFunction(const char *function_name) {
 
 void VM::init(JavaVM* vm) {
     _vm = vm;
-    _vm->GetEnv((void**)&_jvmti, JVMTI_VERSION_1_0);
+    if (_jvmti == NULL) {
+        _vm->GetEnv((void**)&_jvmti, JVMTI_VERSION_1_0);
+    }
 
     jvmtiCapabilities capabilities = {0};
     capabilities.can_generate_all_class_hook_events = 1;

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -31,9 +31,10 @@ inline FunctionType getJvmFunction(const char *function_name) {
 
 void VM::init(JavaVM* vm) {
     _vm = vm;
-    if (_jvmti == NULL) {
-        _vm->GetEnv((void**)&_jvmti, JVMTI_VERSION_1_0);
-    }
+    if (_jvmti != NULL)
+        return;
+
+    _vm->GetEnv((void**)&_jvmti, JVMTI_VERSION_1_0);
 
     jvmtiCapabilities capabilities = {0};
     capabilities.can_generate_all_class_hook_events = 1;


### PR DESCRIPTION
Fixed allocating multiple `jvmtiEnv` per each `On_Attach()` call.