### PR TITLE
Keep sigprofHandler always set

### DIFF
--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -248,7 +248,6 @@ void Profiler::start(int interval, int duration) {
     _freeFrame = 0;
     _frameBufferOverflow = false;
     
-    // Setting deadline
     _deadline = time(NULL) + duration;
 
     setTimer(interval / 1000, (interval % 1000) * 1000);

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -247,7 +247,7 @@ void Profiler::start(int interval, int duration) {
     _frames = (jmethodID *) malloc(_frameBufferSize * sizeof (jmethodID));
     _freeFrame = 0;
     _frameBufferOverflow = false;
-    
+
     _deadline = time(NULL) + duration;
 
     setTimer(interval / 1000, (interval % 1000) * 1000);

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -155,7 +155,8 @@ void Profiler::checkDeadline() {
         ssize_t w = write(STDERR_FILENO, error, sizeof(error) - 1);
         (void) w;
 
-        stop();
+        _running = false;
+        setTimer(0, 0);
     }
 }
 
@@ -259,23 +260,14 @@ void Profiler::stop() {
 
     setTimer(0, 0);
     
-    char text[1024];
-    
     if (_frameBufferOverflow) {
-        int size = snprintf(text, sizeof(text),
-                "Frame buffer overflowed with size %d. "
-                "Consider increasing its size.\n",
-                _frameBufferSize);
-        ssize_t w = write(STDERR_FILENO, text, size);
-        (void) w;
+        std::cerr << "Frame buffer overflowed with size " << _frameBufferSize
+                << ". Consider increasing its size." << std::endl;
     } else {
-        int size = snprintf(text, sizeof (text),
-                "Frame buffer usage %d/%d=%f%%\n",
-                _freeFrame,
-                _frameBufferSize,
-                100.0 * _freeFrame / _frameBufferSize);
-        ssize_t w = write(STDOUT_FILENO, text, size);
-        (void) w;
+        std::cout << "Frame buffer usage "
+                << _freeFrame << "/" << _frameBufferSize
+                << "="
+                << 100.0 * _freeFrame / _frameBufferSize << "%" << std::endl;
     }
 }
 

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -201,12 +201,11 @@ void Profiler::recordSample(void* ucontext) {
 
 void Profiler::setTimer(long sec, long usec) {
     bool enabled = sec | usec;
-
-    struct sigaction sa;
-    sigemptyset(&sa.sa_mask);
     struct itimerval itv = {{sec, usec}, {sec, usec}};
 
     if (enabled) {
+        struct sigaction sa;
+        sigemptyset(&sa.sa_mask);
         sa.sa_handler = NULL;
         sa.sa_sigaction = sigprofHandler;
         sa.sa_flags = SA_RESTART | SA_SIGINFO;

--- a/src/asyncProfiler.cpp
+++ b/src/asyncProfiler.cpp
@@ -267,14 +267,16 @@ void Profiler::stop() {
                 "Frame buffer overflowed with size %d. "
                 "Consider increasing its size.\n",
                 _frameBufferSize);
-        write(STDERR_FILENO, text, size);
+        ssize_t w = write(STDERR_FILENO, text, size);
+        (void) w;
     } else {
         int size = snprintf(text, sizeof (text),
                 "Frame buffer usage %d/%d=%f%%\n",
                 _freeFrame,
                 _frameBufferSize,
                 100.0 * _freeFrame / _frameBufferSize);
-        write(STDOUT_FILENO, text, size);
+        ssize_t w = write(STDOUT_FILENO, text, size);
+        (void) w;
     }
 }
 

--- a/src/asyncProfiler.h
+++ b/src/asyncProfiler.h
@@ -22,6 +22,7 @@
 
 #define DEFAULT_FRAME_BUFFER_SIZE 1024*1024
 #define DEFAULT_INTERVAL          10
+#define DEFAULT_DURATION          3600
 #define DEFAULT_TRACES_TO_DUMP    500
 
 
@@ -109,6 +110,9 @@ class Profiler {
     int _frameBufferSize;
     int _freeFrame;
     bool _frameBufferOverflow;
+    
+    // Seconds resolution is enough
+    time_t _deadline;
 
     u64 hashCallTrace(ASGCT_CallTrace* trace);
     void storeCallTrace(ASGCT_CallTrace* trace);
@@ -129,7 +133,8 @@ class Profiler {
     int samples()     { return _calls_total; }
 
     void frameBufferSize(int size);
-    void start(long interval);
+    void start(int interval) { start(interval, DEFAULT_DURATION); };
+    void start(int interval, int duration);
     void stop();
     void summary(std::ostream& out);
     void dumpRawTraces(std::ostream& out);

--- a/src/asyncProfiler.h
+++ b/src/asyncProfiler.h
@@ -110,7 +110,7 @@ class Profiler {
     int _frameBufferSize;
     int _freeFrame;
     bool _frameBufferOverflow;
-    
+
     // Seconds resolution is enough
     time_t _deadline;
 


### PR DESCRIPTION
On `Profiler::start()` we set `SIGPROF` signal handler and start the timer.
On `Profiler::stop()` we just stop the timer.
Otherwise, resetting `SIGPROF` signal handler on `Profiler::stop()` under frequent `start()`/`stop()` calls leads to early termination of the application due to unprocessed signal.