### PR TITLE
Dump traces in FlameGraph format

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ $ jps
 8983 Computey
 $ ./profiler.sh -p 8983 -o interval:100000000 -a start
 $ ./profiler.sh -p 8983 -f /tmp/traces.txt -a dump
-$ FlameGraph/stackcollapse-ljp.awk /tmp/traces.txt > /tmp/folded.stacks
-$ FlameGraph/flamegraph.pl /tmp/folded.stacks > /tmp/flamegraph.svg
+$ FlameGraph/flamegraph.pl --colors=java /tmp/traces.txt > /tmp/flamegraph.svg
 ```
 
 ## All Agent Options
@@ -138,22 +137,16 @@ Example: `./profiler.sh -p 8983 -o frameBufferSize:1000000 -a start`.
 * `dumpRawTraces:filename` - stops profiling and dumps the raw trace information
 to the specified file. Example: `./profiler.sh -p 8983 -f /tmp/traces -a dump`.
 
-The format of the raw trace file is a collection of call stacks, where the first
-line is the number of appearances of that call stack, the number of frames in
-the call stack, followed by the call stack with each frame on a separate line.
+The format of the raw trace file is a collection of call stacks, where each line
+is a semicolon separated list of frames followed by the sample count.
 For example:
 
 ```
-1056	5	Primes::isPrime
-		Primes::primesThread
-		Primes::access$000
-		Primes$1::run
-		java.lang.Thread::run
+java/lang/Thread.run;Primes$1.run;Primes.access$000;Primes.primesThread;Primes.isPrime 1056
 ```
 
 This stack appeared 1056 times in the trace. This is the same stack trace format
-used by the [Lightweight Java Profiler](https://code.google.com/archive/p/lightweight-java-profiler/),
-and can be easily used for generating flame graphs.
+used by the [FlameGraph](https://github.com/brendangregg/FlameGraph) script.
 
 ## Restrictions/Limitations
 

--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -105,7 +105,8 @@ const char* StringTable::add(const char* s, int length) {
 }
 
 
-CodeCache::CodeCache(const char* name, const void* min_address, const void* max_address) {
+CodeCache::CodeCache(const char* name, bool solid,
+                     const void* min_address, const void* max_address) {
     _name = strdup(name);
     _capacity = INITIAL_CODE_CACHE_CAPACITY;
     _count = 0;
@@ -113,6 +114,7 @@ CodeCache::CodeCache(const char* name, const void* min_address, const void* max_
     _strings = NULL;
     _min_address = min_address;
     _max_address = max_address;
+    _solid = solid;
 }
 
 CodeCache::~CodeCache() {
@@ -199,5 +201,5 @@ jmethodID CodeCache::binary_search(const void* address) {
         }
     }
 
-    return low > 0 ? _blobs[low - 1]._method : asJavaMethod(_name);
+    return _solid && low > 0 ? _blobs[low - 1]._method : asJavaMethod(_name);
 }

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -91,9 +91,10 @@ class CodeCache {
     StringTable* _strings;
     const void* _min_address;
     const void* _max_address;
+    bool _solid;  // true, if there are no holes between functions
 
   public:
-    CodeCache(const char* name,
+    CodeCache(const char* name, bool solid,
               const void* min_address = (const void*)-1,
               const void* max_address = (const void*)0);
     ~CodeCache();

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -29,11 +29,11 @@ class MethodName {
     char _buf[520];
     const char* _str;
 
-    char* fixClassName(char* name);
+    char* fixClassName(char* name, bool dotted = false);
     char* demangle(char* name);
 
   public:
-    MethodName(jmethodID method, const char* sep = ".");
+    MethodName(jmethodID method, bool dotted = false);
 
     const char* toString() { return _str; }
 };

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -129,7 +129,7 @@ class Profiler {
         _running(false), 
         _frame_buffer(NULL), 
         _frame_buffer_size(DEFAULT_FRAME_BUFFER_SIZE),
-        _java_code("[jvm]"),
+        _java_code("[jvm]", false),
         _native_libs(0) {
     }
 

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -81,6 +81,7 @@ void Symbols::parseKernelSymbols(CodeCache* cc) {
     std::string str;
 
     while (std::getline(maps, str)) {
+        str += "_[k]";
         SymbolMap map(str.c_str());
         char type = map.type();
         if (type == 'T' || type == 't' || type == 'V' || type == 'v' || type == 'W' || type == 'w') {

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -141,7 +141,7 @@ void Symbols::parseFile(CodeCache* cc, const char* fileName, const char* base) {
 int Symbols::parseMaps(CodeCache** array, int size) {
     int count = 0;
     if (count < size) {
-        CodeCache* cc = new CodeCache("[kernel]");
+        CodeCache* cc = new CodeCache("[kernel]", true);
         parseKernelSymbols(cc);
         array[count++] = cc;
     }
@@ -152,7 +152,7 @@ int Symbols::parseMaps(CodeCache** array, int size) {
     while (count < size && std::getline(maps, str)) {
         MemoryMap map(str.c_str());
         if (map.isExecutable() && map.file()[0] != 0) {
-            CodeCache* cc = new CodeCache(map.file(), map.addr(), map.end());
+            CodeCache* cc = new CodeCache(map.file(), false, map.addr(), map.end());
             const char* base = map.addr() - map.offs();
             if (map.inode() != 0) {
                 parseFile(cc, map.file(), base);


### PR DESCRIPTION
- `dumpRawTraces` now prints stack traces in the FlameGraph format, so the intermediate step of running `stackcollapse-ljp` is no longer needed;
 - Java classes are printed in the slashed format (e.g. java/lang/Thread), and `_[k]` is appended to the kernel symbols to match `--colors=java` scheme of the FlameGraph script.