### PR TITLE
Basic TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: cpp
+
+dist: trusty
+
+sudo: required
+
+before_install:
+  - sudo apt-get install default-jdk
+
+script: make


### PR DESCRIPTION
This introduces a .travis.yml file that configures a Travis CI
build to run on Ubuntu Trusty (14.04), install the JDK, and build
the project. The next step would be adding automatic tests.

You can see over here what the result looks like (enabled for
my fork of the repo): https://travis-ci.org/goldshtn/async-profiler/builds

@apangin You would need (as the repo owner) to log in on
https://travis-ci.org, authorize Travis to access your GitHub
repositories, and check the checkbox next to the async-profiler
repository so that we get an automatic build. Then we could
add a build badge, configure pull requests to require the build
to pass, and so on. If you'd like I can configure this for you,
but you would need to give me admin access to the repo.

Resolves #20.