### PR TITLE
Parse external debuginfo

### DIFF
--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -117,6 +117,7 @@ CodeCache::CodeCache(const char* name, bool solid,
     _min_address = min_address;
     _max_address = max_address;
     _solid = solid;
+    _debug_symbols = false;
 }
 
 CodeCache::~CodeCache() {

--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -107,8 +107,7 @@ const char* StringTable::add(const char* s, int length) {
 }
 
 
-CodeCache::CodeCache(const char* name,
-                     const void* min_address, const void* max_address) {
+CodeCache::CodeCache(const char* name, const void* min_address, const void* max_address) {
     _name = strdup(name);
     _capacity = INITIAL_CODE_CACHE_CAPACITY;
     _count = 0;
@@ -116,7 +115,6 @@ CodeCache::CodeCache(const char* name,
     _strings = NULL;
     _min_address = min_address;
     _max_address = max_address;
-    _debug_symbols = false;
 }
 
 CodeCache::~CodeCache() {

--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -107,7 +107,7 @@ const char* StringTable::add(const char* s, int length) {
 }
 
 
-CodeCache::CodeCache(const char* name, bool solid,
+CodeCache::CodeCache(const char* name,
                      const void* min_address, const void* max_address) {
     _name = strdup(name);
     _capacity = INITIAL_CODE_CACHE_CAPACITY;
@@ -116,7 +116,6 @@ CodeCache::CodeCache(const char* name, bool solid,
     _strings = NULL;
     _min_address = min_address;
     _max_address = max_address;
-    _solid = solid;
     _debug_symbols = false;
 }
 
@@ -204,5 +203,9 @@ jmethodID CodeCache::binary_search(const void* address) {
         }
     }
 
-    return _solid && low > 0 ? _blobs[low - 1]._method : asJavaMethod(_name);
+    // Symbols with zero size can be valid functions: e.g. ASM entry points or kernel code
+    if (low > 0 && _blobs[low - 1]._start == _blobs[low - 1]._end) {
+        return _blobs[low - 1]._method;
+    }
+    return asJavaMethod(_name);
 }

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -91,7 +91,8 @@ class CodeCache {
     StringTable* _strings;
     const void* _min_address;
     const void* _max_address;
-    bool _solid;  // true, if there are no holes between functions
+    bool _solid;              // true, if there are no holes between functions
+    bool _debug_symbols;      // true, if this CodeCache contains non-public symbols
 
   public:
     CodeCache(const char* name, bool solid,
@@ -112,6 +113,14 @@ class CodeCache {
 
     bool contains(const void* address) {
         return address >= _min_address && address < _max_address;
+    }
+
+    bool hasDebugSymbols() {
+        return _debug_symbols;
+    }
+
+    void setDebugSymbols(bool debug_symbols) {
+        _debug_symbols = debug_symbols;
     }
 };
 

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -91,7 +91,6 @@ class CodeCache {
     StringTable* _strings;
     const void* _min_address;
     const void* _max_address;
-    bool _debug_symbols;      // true, if this CodeCache contains non-public symbols
 
   public:
     CodeCache(const char* name,
@@ -112,14 +111,6 @@ class CodeCache {
 
     bool contains(const void* address) {
         return address >= _min_address && address < _max_address;
-    }
-
-    bool hasDebugSymbols() {
-        return _debug_symbols;
-    }
-
-    void setDebugSymbols(bool debug_symbols) {
-        _debug_symbols = debug_symbols;
     }
 };
 

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -91,11 +91,10 @@ class CodeCache {
     StringTable* _strings;
     const void* _min_address;
     const void* _max_address;
-    bool _solid;              // true, if there are no holes between functions
     bool _debug_symbols;      // true, if this CodeCache contains non-public symbols
 
   public:
-    CodeCache(const char* name, bool solid,
+    CodeCache(const char* name,
               const void* min_address = (const void*)-1,
               const void* max_address = (const void*)0);
     ~CodeCache();

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -24,6 +24,7 @@
 #include "profiler.h"
 #include "perfEvent.h"
 #include "stackFrame.h"
+#include "symbols.h"
 
 
 Profiler Profiler::_instance;

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -19,7 +19,7 @@
 
 #include <iostream>
 #include "spinLock.h"
-#include "symbols.h"
+#include "codeCache.h"
 #include "vmEntry.h"
 
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -129,7 +129,7 @@ class Profiler {
         _running(false), 
         _frame_buffer(NULL), 
         _frame_buffer_size(DEFAULT_FRAME_BUFFER_SIZE),
-        _java_code("[jvm]", false),
+        _java_code("[jvm]"),
         _native_libs(0) {
     }
 

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -202,7 +202,7 @@ void Symbols::parseElf(CodeCache* cc, const char* addr, const char* base, BuildI
 int Symbols::parseMaps(CodeCache** array, int size) {
     int count = 0;
     if (count < size) {
-        CodeCache* cc = new CodeCache("[kernel]", true);
+        CodeCache* cc = new CodeCache("[kernel]");
         parseKernelSymbols(cc);
         cc->sort();
         array[count++] = cc;
@@ -214,7 +214,7 @@ int Symbols::parseMaps(CodeCache** array, int size) {
     while (count < size && std::getline(maps, str)) {
         MemoryMap map(str.c_str());
         if (map.isExecutable() && map.file()[0] != 0) {
-            CodeCache* cc = new CodeCache(map.file(), false, map.addr(), map.end());
+            CodeCache* cc = new CodeCache(map.file(), map.addr(), map.end());
             const char* base = map.addr() - map.offs();
 
             if (map.inode() != 0) {

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -173,7 +173,7 @@ void Symbols::parseElf(CodeCache* cc, const char* addr, const char* base, BuildI
 
     for (int i = 0; i < ehdr->e_shnum; i++) {
         Elf64_Shdr* section = (Elf64_Shdr*)(sections + i * ehdr->e_shentsize);
-        if (section->sh_type == SHT_SYMTAB || section->sh_type == SHT_DYNSYM) {
+        if (section->sh_type == SHT_SYMTAB || section->sh_type == SHT_DYNSYM && build_id != NULL) {
             Elf64_Shdr* strtab = (Elf64_Shdr*)(sections + section->sh_link * ehdr->e_shentsize);
             const char* strings = cc->addStrings(addr + strtab->sh_offset, strtab->sh_size);
 

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -122,25 +122,18 @@ void Symbols::parseLibrarySymbols(CodeCache* cc, const char* lib_name, const cha
         if (parseFile(cc, path, base, NULL)) return;
     }
 
-    // Do not even try to add debug prefix/suffix if lib_name is too long
-    if (strlen(lib_name) >= sizeof(path) - sizeof("/usr/lib/debug")) {
-        return;
+    // 2. /usr/lib/debug/path/to/lib.so
+    if (snprintf(path, sizeof(path), "/usr/lib/debug%s", lib_name) < sizeof(path)) {
+        if (parseFile(cc, path, base, NULL)) return;
     }
 
-    // 2. /usr/lib/debug/path/to/lib.so
-    snprintf(path, sizeof(path), "/usr/lib/debug%s", lib_name);
-    if (parseFile(cc, path, base, NULL)) return;
+    // 3. /usr/lib/debug/path/to/lib.so.debug
+    if (snprintf(path, sizeof(path), "/usr/lib/debug%s.debug", lib_name) < sizeof(path)) {
+        if (parseFile(cc, path, base, NULL)) return;
+    }
 
-    // 3. /path/to/lib.so.debug
-    snprintf(path, sizeof(path), "%s.debug", lib_name);
-    if (parseFile(cc, path, base, NULL)) return;
-
-    // 4. /path/to/.debug/lib.so
-    const char* slash = strrchr(lib_name, '/');
-    if (slash != NULL) {
-        int dir_len = slash - lib_name;
-        strncpy(path, lib_name, dir_len);
-        snprintf(path + dir_len, sizeof(path) - dir_len, "/.debug%s", slash);
+    // 4. /path/to/lib.so.debug
+    if (snprintf(path, sizeof(path), "%s.debug", lib_name) < sizeof(path)) {
         if (parseFile(cc, path, base, NULL)) return;
     }
 }

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -198,7 +198,7 @@ bool ElfParser::loadSymbolsUsingDebugLink() {
     }
 
     // 3. /usr/lib/debug/path/to/libjvm.so.debug
-    if (!result && snprintf(path, sizeof(path), "/usr/lib/debug/%s/%s", dirname, debuglink) < sizeof(path)) {
+    if (!result && snprintf(path, sizeof(path), "/usr/lib/debug%s/%s", dirname, debuglink) < sizeof(path)) {
         result = parseFile(_cc, _base, path, false);
     }
 

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -20,12 +20,33 @@
 #include "codeCache.h"
 
 
+class BuildId {
+  private:
+    unsigned char _value[64];
+    int _length;
+
+  public:
+    BuildId() : _length(0) {
+    }
+
+    int length() {
+        return _length;
+    }
+
+    unsigned char operator[](int index) {
+        return _value[index];
+    }
+
+    void set(const char* value, int length);
+};
+
 class Symbols {
   private:
     static void parseKernelSymbols(CodeCache* cc);
-    static void parseElf(CodeCache* cc, const char* addr, const char* base);
-    static void parseFile(CodeCache* cc, const char* fileName, const char* base);
-  
+    static void parseLibrarySymbols(CodeCache* cc, const char* lib_name, const char* base);
+    static bool parseFile(CodeCache* cc, const char* file_name, const char* base, BuildId* build_id);
+    static void parseElf(CodeCache* cc, const char* addr, const char* base, BuildId* build_id);
+
   public:
     static int parseMaps(CodeCache** array, int size);
 };

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -17,35 +17,62 @@
 #ifndef _SYMBOLS_H
 #define _SYMBOLS_H
 
+#include <elf.h>
 #include "codeCache.h"
 
 
-class BuildId {
+typedef Elf64_Ehdr ElfHeader;
+typedef Elf64_Shdr ElfSection;
+typedef Elf64_Nhdr ElfNote;
+typedef Elf64_Sym  ElfSymbol;
+
+class ElfParser {
   private:
-    unsigned char _value[64];
-    int _length;
+    CodeCache* _cc;
+    const char* _base;
+    const char* _file_name;
+    ElfHeader* _header;
+    const char* _sections;
+
+    ElfParser(CodeCache* cc, const char* base, const void* addr, const char* file_name = NULL) {
+        _cc = cc;
+        _base = base;
+        _file_name = file_name;
+        _header = (ElfHeader*)addr;
+        _sections = (const char*)addr + _header->e_shoff;
+    }
+
+    bool valid_header() {
+        unsigned char* ident = _header->e_ident;
+        return ident[0] == 0x7f && ident[1] == 'E' && ident[2] == 'L' && ident[3] == 'F'
+            && ident[4] == ELFCLASS64 && ident[5] == ELFDATA2LSB && ident[6] == EV_CURRENT
+            && _header->e_shstrndx != SHN_UNDEF;
+    }
+
+    ElfSection* section(int index) {
+        return (ElfSection*)(_sections + index * _header->e_shentsize);
+    }
+
+    const char* at(ElfSection* section) {
+        return (const char*)_header + section->sh_offset;
+    }
+
+    ElfSection* findSection(uint32_t type, const char* name);
+
+    void loadSymbols(bool use_debug);
+    bool loadSymbolsUsingBuildId();
+    bool loadSymbolsUsingDebugLink();
+    void loadSymbolTable(ElfSection* symtab);
 
   public:
-    BuildId() : _length(0) {
-    }
-
-    int length() {
-        return _length;
-    }
-
-    unsigned char operator[](int index) {
-        return _value[index];
-    }
-
-    void set(const char* value, int length);
+    static bool parseFile(CodeCache* cc, const char* base, const char* file_name, bool use_debug);
+    static void parseMem(CodeCache* cc, const char* base, const void* addr);
 };
+
 
 class Symbols {
   private:
     static void parseKernelSymbols(CodeCache* cc);
-    static void parseLibrarySymbols(CodeCache* cc, const char* lib_name, const char* base);
-    static bool parseFile(CodeCache* cc, const char* file_name, const char* base, BuildId* build_id);
-    static void parseElf(CodeCache* cc, const char* addr, const char* base, BuildId* build_id);
 
   public:
     static int parseMaps(CodeCache** array, int size);


### PR DESCRIPTION
If shared library misses .strtab section, look for debug symbols in the external sources:

1. /usr/lib/debug/.build-id/ab/cdef1234.debug, where abcdef1234 - is ID obtained from `.note.gnu.build-id` section;
2. /usr/lib/debug/path/to/lib.so
3. /usr/lib/debug/path/to/lib.so.debug
4. /path/to/lib.so.debug

Note: to keep things simple we do not parse .gnu_debuglink contents, but rather search through a list of common locations.