### PR TITLE
Basic smoke test support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /nbproject/
+*.class

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ sudo: required
 before_install:
   - sudo apt-get install default-jdk
 
-script: make
+script: make && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ sudo: required
 
 before_install:
   - sudo apt-get install default-jdk
+  - sudo bash -c 'echo 1 > /proc/sys/kernel/perf_event_paranoid'
 
 script: make && make test

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ CPP=g++
 CPPFLAGS=-O2
 INCLUDES=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
 
+.PHONY: test
+
 all: build build/$(LIB_PROFILER) build/$(JATTACH)
 
 build:
@@ -16,6 +18,9 @@ build/$(LIB_PROFILER): src/*.cpp src/*.h
 
 build/$(JATTACH): src/jattach.c
 	$(CC) $(CFLAGS) -o $@ $^
+
+test: all
+	test/smoke-test.sh
 
 clean:
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ be tuned in order to allow non-root users to use `perf_events`.
 
 ## Building
 
+Build status: [![Build Status](https://travis-ci.org/apangin/async-profiler.svg?branch=master)](https://travis-ci.org/apangin/async-profiler)
+
 Make sure the `JAVA_HOME` environment variable points to your JDK installation,
 and then run `make`. GCC is required. After building, the profiler agent binary
 will be in the `build` subdirectory. Additionally, a small Java application

--- a/profiler.sh
+++ b/profiler.sh
@@ -3,7 +3,8 @@
 OPTIND=1
 SCRIPT_DIR=$(dirname $0)
 JATTACH=$SCRIPT_DIR/build/jattach
-PROFILER=$(realpath $SCRIPT_DIR/build/libasyncProfiler.so)
+# realpath is not present on all distros, notably on the Travis CI image
+PROFILER=$(readlink -f $SCRIPT_DIR/build/libasyncProfiler.so)
 ACTION=""
 PID=""
 START_OPTIONS=""

--- a/test/Target.java
+++ b/test/Target.java
@@ -1,0 +1,30 @@
+import java.util.Scanner;
+import java.io.File;
+
+class Target {
+  private static volatile int value;
+
+  private static void method1() {
+    for (int i = 0; i < 1000000; ++i)
+      ++value;
+  }
+
+  private static void method2() {
+    for (int i = 0; i < 1000000; ++i)
+      ++value;
+  }
+
+  private static void method3() throws Exception {
+    for (int i = 0; i < 1000; ++i) {
+      new Scanner(new File("/proc/cpuinfo")).useDelimiter("\\Z").next();
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    while (true) {
+      method1();
+      method2();
+      method3();
+    }
+  }
+}

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e  # exit on any failure
+set -x  # print all executed lines
+
+pushd $(dirname $0)
+
+javac Target.java
+java Target &
+
+FILENAME=/tmp/java.trace
+JAVAPID=$!
+
+sleep 1     # allow the Java runtime to initialize
+../profiler.sh -p $JAVAPID -a start
+sleep 5
+../profiler.sh -p $JAVAPID -a dump -f $FILENAME
+
+kill $JAVAPID
+
+function assert_string() {
+  if ! grep -q "$1" $FILENAME; then
+    exit 1
+  fi
+}
+
+assert_string "Target.main;Target.method1 "
+assert_string "Target.main;Target.method2 "
+assert_string "Target.main;Target.method3;java/util/Scanner"
+
+popd


### PR DESCRIPTION
The smoke test runs the Java target application, attaches the profiler,
waits for 5 seconds, stops the profiler and dumps the results to a
file, and then parses the file looking for patterns that we know
must appear. This is a very basic smoke test that will only make sure
we haven't broken anything completely obvious.

The Makefile and Travis configuration are also updated to run the test.

Resolves #21.