### PR TITLE
#28: Support older gcc and Linux headers

### DIFF
--- a/src/perfEvent.cpp
+++ b/src/perfEvent.cpp
@@ -27,6 +27,17 @@
 
 #define rmb()  asm volatile("lfence":::"memory")
 
+// Ancient fcntl.h does not define F_SETOWN_EX constants and structures
+#ifndef F_SETOWN_EX
+#define F_SETOWN_EX  15
+#define F_OWNER_TID  0
+
+struct f_owner_ex {
+    int type;
+    pid_t pid;
+};
+#endif // F_SETOWN_EX
+
 
 int PerfEvent::_max_events = 0;
 PerfEvent* PerfEvent::_events = NULL;
@@ -39,7 +50,7 @@ void PerfEvent::init() {
 }
 
 int PerfEvent::tid() {
-    return syscall(SYS_gettid);
+    return syscall(__NR_gettid);
 }
 
 int PerfEvent::getMaxPid() {
@@ -65,7 +76,7 @@ void PerfEvent::createForThread(int tid) {
     attr.exclude_idle = 1;
     attr.precise_ip = 2;
 
-    int fd = syscall(SYS_perf_event_open, &attr, tid, -1, -1, 0);
+    int fd = syscall(__NR_perf_event_open, &attr, tid, -1, -1, 0);
     if (fd == -1) {
         perror("perf_event_open failed");
         return;

--- a/src/spinLock.h
+++ b/src/spinLock.h
@@ -17,6 +17,9 @@
 #ifndef _SPINLOCK_H
 #define _SPINLOCK_H
 
+#define x86_pause()  asm volatile("pause")
+
+
 // Cannot use regular mutexes inside signal handler
 class SpinLock {
   private:
@@ -36,7 +39,7 @@ class SpinLock {
 
     void spinLock() {
         while (!tryLock()) {
-            __builtin_ia32_pause();
+            x86_pause();
         }
     }
 

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -148,7 +148,7 @@ bool ElfParser::loadSymbolsUsingBuildId() {
     }
 
     ElfNote* note = (ElfNote*)at(section);
-    if (note->n_namesz != 4 || note->n_descsz < 2 || note->n_descsz > 64 || note->n_type != NT_GNU_BUILD_ID) {
+    if (note->n_namesz != 4 || note->n_descsz < 2 || note->n_descsz > 64) {
         return false;
     }
 


### PR DESCRIPTION
Resolves #28

Fixed compiler errors encountered on older systems:
- '__builtin_ia32_pause' was not declared in this scope
- 'SYS_perf_event_open' was not declared in this scope
- aggregate 'f_owner_ex ex' has incomplete type and cannot be defined
- 'F_OWNER_TID' was not declared in this scope
- 'F_SETOWN_EX' was not declared in this scope
- 'NT_GNU_BUILD_ID' was not declared in this scope

Tested on Linux 2.6.39, gcc 4.1.2, JDK 6u26