### PR TITLE
Ignore SIGPIPE during socket operations to avoid silent exits

### DIFF
--- a/src/jattach.c
+++ b/src/jattach.c
@@ -128,6 +128,7 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    signal(SIGPIPE, SIG_IGN);
     if (!check_socket(pid) && !start_attach_mechanism(pid)) {
         perror("Could not start attach mechanism");
         return 1;

--- a/src/jattach.c
+++ b/src/jattach.c
@@ -128,7 +128,9 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    // Make write() return EPIPE instead of silent process termination
     signal(SIGPIPE, SIG_IGN);
+
     if (!check_socket(pid) && !start_attach_mechanism(pid)) {
         perror("Could not start attach mechanism");
         return 1;


### PR DESCRIPTION
Currently if one has problems with permissions, jattach will print
`Connected to remote JVM` to stdout and silently exits due to unhandled `SIGPIPE` signal.


Before patch:
```
./profiler.sh -p ... -a start 
echo $?
141
```

After patch:
```
./profiler.sh -p ... -a start
Error writing to socket: Broken pipe
echo $?
1
```