### PR TITLE
Resolves #32: Revise usage of jmethodID to encode strings

### DIFF
--- a/src/perfEvent.cpp
+++ b/src/perfEvent.cpp
@@ -127,7 +127,7 @@ void PerfEvent::destroyForThread(int tid) {
         event->_fd = 0;
     }
     if (event->_page != NULL) {
-        event->spinLock();
+        event->lock();
         munmap(event->_page, 2 * PAGE_SIZE);
         event->_page = NULL;
         event->unlock();

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -28,13 +28,13 @@ typedef Elf64_Sym  ElfSymbol;
 
 class ElfParser {
   private:
-    CodeCache* _cc;
+    NativeCodeCache* _cc;
     const char* _base;
     const char* _file_name;
     ElfHeader* _header;
     const char* _sections;
 
-    ElfParser(CodeCache* cc, const char* base, const void* addr, const char* file_name = NULL) {
+    ElfParser(NativeCodeCache* cc, const char* base, const void* addr, const char* file_name = NULL) {
         _cc = cc;
         _base = base;
         _file_name = file_name;
@@ -65,17 +65,17 @@ class ElfParser {
     void loadSymbolTable(ElfSection* symtab);
 
   public:
-    static bool parseFile(CodeCache* cc, const char* base, const char* file_name, bool use_debug);
-    static void parseMem(CodeCache* cc, const char* base, const void* addr);
+    static bool parseFile(NativeCodeCache* cc, const char* base, const char* file_name, bool use_debug);
+    static void parseMem(NativeCodeCache* cc, const char* base, const void* addr);
 };
 
 
 class Symbols {
   private:
-    static void parseKernelSymbols(CodeCache* cc);
+    static void parseKernelSymbols(NativeCodeCache* cc);
 
   public:
-    static int parseMaps(CodeCache** array, int size);
+    static int parseMaps(NativeCodeCache** array, int size);
 };
 
 #endif // _SYMBOLS_H

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -20,6 +20,9 @@
 #include <jvmti.h>
 
 
+// Denotes ASGCT_CallFrame with string name instead of Java method ID
+const jint BCI_NATIVE_FRAME = -2;
+
 typedef struct {
     jint bci;
     jmethodID method_id;


### PR DESCRIPTION
Call traces are now stored as an array of `ASGCT_CallFrame` (instead of an array of `jmethodID`).

`bci` field is used to distringuish Java methods from native functions. The special value -2 means that jmethodID should be treated as a string holding the native function name.

Related changes:

- StringTable is completely removed; all function names are strdup'ed.
- CodeCache is split into Java CodeCache and NativeCodeCache: the former holds `jmethodID` while the latter holds `const char*`.
- JITted methods and VM generated stubs are now in two separate CodeCaches.
- CodeCache is updated under lock; when it grows, the previously allocated memory is reclaimed.

Linux/ARM builds do not crash anymore during profile dumping.