### PR TITLE
Better argument processing. Resolves #15, #19, #27.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Example:
 $ jps
 9234 Jps
 8983 Computey
-$ ./profiler.sh --start 8983
-$ ./profiler.sh --stop 8983
+$ ./profiler.sh start 8983
+$ ./profiler.sh stop 8983
 ```
 
 Alternatively, you may specify `-d` (duration) argument to profile
@@ -119,6 +119,19 @@ $ FlameGraph/flamegraph.pl --colors=java /tmp/traces.txt > /tmp/flamegraph.svg
 The following is a complete list of the command-line options accepted by
 `profiler.sh` script.
 
+* `start` - starts profiling in semi-automatic mode, i.e. profiler will run
+until `stop` command is explicitly called.
+
+* `stop` - stops profiling and prints the report.
+
+* `status` - prints profiling status: whether profiler is active and
+for how long.
+
+* `-d N` - the profiling duration, in seconds. If no `start`, `stop`
+or `status` option is given, the profiler will run for the specified period
+of time and then automatically stop.  
+Example: `./profiler.sh -d 30 8983`
+
 * `-i N` - sets the profiling interval, in nanoseconds. Only CPU active time
 is counted. No samples are collected while CPU is idle. The default is
 1000000 (1ms).  
@@ -128,19 +141,6 @@ Example: `./profiler.sh -i 100000 8983`
 method ids that should fit in the buffer. If you receive messages about an
 insufficient frame buffer size, increase this value from the default.  
 Example: `./profiler.sh -b 5000000 8983`
-
-* `--start` - starts profiling in semi-automatic mode, i.e. profiler will run
-until `--stop` command is explicitly called.
-
-* `--stop` - stops profiling and prints the report.
-
-* `--status` - prints profiling status: whether profiler is active and
-for how long.
-
-* `-d N` - the profiling duration, in seconds. If no `--start`, `--stop`
-or `--status` option is given, the profiler will run for the specified period
-of time and then automatically stop.  
-Example: `./profiler.sh -d 30 8983`
 
 * `-o fmt[,fmt...]` - specifies what information to dump when profiling ends.
 This is a comma-separated list of the following options:

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Example:
 $ jps
 9234 Jps
 8983 Computey
-$ ./profiler.sh -p 8983 -a start
-$ ./profiler.sh -p 8983 -a stop
+$ ./profiler.sh --start 8983
+$ ./profiler.sh --stop 8983
 ```
 
-By default, the profiling frequency is 100Hz (every 10ms). Here is a sample of
+By default, the profiling frequency is 1000Hz (every 1ms). Here is a sample of
 the output printed to the Java application's terminal:
 
 ```
@@ -103,8 +103,7 @@ solution can be tailored to other visualization tools.
 $ jps
 9234 Jps
 8983 Computey
-$ ./profiler.sh -p 8983 -o interval:100000000 -a start
-$ ./profiler.sh -p 8983 -f /tmp/traces.txt -a dump
+$ ./profiler.sh -d 30 -o flamegraph -f /tmp/traces.txt 8983
 $ FlameGraph/flamegraph.pl --colors=java /tmp/traces.txt > /tmp/flamegraph.svg
 ```
 
@@ -113,7 +112,7 @@ $ FlameGraph/flamegraph.pl --colors=java /tmp/traces.txt > /tmp/flamegraph.svg
 The following is a complete list of the command-line options accepted by the
 agent. Some options can be combined, e.g. the profiling interval can be
 provided at the same time as the `start` command, by separating them with
-commas: `interval:1000000,start`. When using the `profiler.sh` helper script,
+commas: `interval=1000000,start`. When using the `profiler.sh` helper script,
 start/stop/dump are actions, and the rest of the switches are provided as
 options. See examples below for how to use these options with the helper script,
 but you can also pass them directly to the agent using the `jattach` utility,
@@ -121,11 +120,6 @@ which is built as part of this tool.
 
 * `interval:N` - sets the profiling interval, in CPU cycles. The default is
 10000000 (10M) cycles. Example: `./profiler.sh -p 8983 -o interval:100000 -a start`.
-
-* `duration:N` - sets the duration of the trace, in seconds. After this time,
-the trace will stop automatically. The default is 3600 seconds (1 hour).
-Example: `./profiler.sh -p 8983 -o duration:60 -a start`. _NOTE: This feature
-is not currently supported; profiling will not stop automatically._
 
 * `frameBufferSize:N` - sets the frame buffer size, in the number of Java
 method ids that should fit in the buffer. If you receive messages about an

--- a/profiler.sh
+++ b/profiler.sh
@@ -88,7 +88,7 @@ done
 
 # if no -f argument is given, use temporary file to transfer output to caller terminal
 if [[ $USE_TMP ]]; then
-    FILE="/tmp/async-profiler-${PID}.tmp";
+    FILE=$(mktemp --tmpdir async-profiler.XXXXXXXX)
 fi
 
 case $ACTION in

--- a/profiler.sh
+++ b/profiler.sh
@@ -9,6 +9,7 @@ usage() {
     echo "  -d duration       run profiling for <duration> seconds"
     echo "  -f filename       dump output to <filename>"
     echo "  -i interval       sampling interval in nanoseconds"
+    echo "  -b bufsize        frame buffer size"
     echo "  -o fmt[,fmt...]   output format: summary|traces|methods|flamegraph"
     echo ""
     echo "Example: $0 -d 30 -f profile.fg -o flamegraph 3456"
@@ -26,7 +27,8 @@ ACTION=""
 DURATION="60"
 FILE=""
 INTERVAL=""
-OUTPUT="summary,traces,methods"
+FRAMEBUF=""
+OUTPUT="summary,traces=200,methods=200"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -48,6 +50,10 @@ while [[ $# -gt 0 ]]; do
             INTERVAL=",interval=$2"
             shift
             ;;
+        -b)
+            FRAMEBUF=",framebuf=$2"
+            shift
+            ;;
         -o)
             OUTPUT=",$2"
             shift
@@ -67,7 +73,7 @@ done
 
 case $ACTION in
     --start)
-        $JATTACH $PID load $PROFILER true start$INTERVAL > /dev/null
+        $JATTACH $PID load $PROFILER true start$INTERVAL$FRAMEBUF > /dev/null
         ;;
     --stop)
         $JATTACH $PID load $PROFILER true stop$FILE$OUTPUT > /dev/null
@@ -76,7 +82,7 @@ case $ACTION in
         $JATTACH $PID load $PROFILER true status > /dev/null
         ;;
     *)
-        $JATTACH $PID load $PROFILER true start$INTERVAL > /dev/null
+        $JATTACH $PID load $PROFILER true start$INTERVAL$FRAMEBUF > /dev/null
         if [ $? -ne 0 ]; then
             exit 1
         fi

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include "arguments.h"
+
+
+// Parses agent arguments.
+// The format of the string is:
+//     arg[,arg...]
+// where arg is one of the following options:
+//     start         - start profiling
+//     stop          - stop profiling
+//     status        - print profiling status (inactive / running for X seconds)
+//     flamegraph    - dump profile in FlameGraph format
+//     summary       - dump profiling summary (number of collected samples of each type)
+//     traces[=N]    - dump top N call traces
+//     methods[=N]   - dump top N methods (aka flat profile)
+//     interval=N    - sampling interval in ns (default: 1'000'000, i.e. 1 ms)
+//     framebuf=N    - size of the buffer for stack frames (default: 1'000'000)
+//     file=FILENAME - output file name for dumping
+//
+// It is possible to specify multiple dump options at the same time
+
+const char* Arguments::parse(char* args) {
+    if (strlen(args) >= sizeof(_buf)) {
+        return "Argument list too long";
+    }
+    strcpy(_buf, args);
+
+    for (char* arg = strtok(_buf, ","); arg != NULL; arg = strtok(NULL, ",")) {
+        char* value = strchr(arg, '=');
+        if (value != NULL) *value++ = 0;
+
+        if (strcmp(arg, "start") == 0) {
+            _action = ACTION_START;
+        } else if (strcmp(arg, "stop") == 0) {
+            _action = ACTION_STOP;
+        } else if (strcmp(arg, "status") == 0) {
+            _action = ACTION_STATUS;
+        } else if (strcmp(arg, "flamegraph") == 0) {
+            _action = ACTION_DUMP;
+            _dump_flamegraph = true;
+        } else if (strcmp(arg, "summary") == 0) {
+            _action = ACTION_DUMP;
+            _dump_summary = true;
+        } else if (strcmp(arg, "traces") == 0) {
+            _action = ACTION_DUMP;
+            _dump_traces = value == NULL ? INT_MAX : atoi(value);
+        } else if (strcmp(arg, "methods") == 0) {
+            _action = ACTION_DUMP;
+            _dump_methods = value == NULL ? INT_MAX : atoi(value);
+        } else if (strcmp(arg, "interval") == 0) {
+            if (value == NULL || (_interval = atoi(value)) <= 0) {
+                return "interval must be > 0";
+            }
+        } else if (strcmp(arg, "framebuf") == 0) {
+            if (value == NULL || (_framebuf = atoi(value)) <= 0) {
+                return "framebuf must be > 0";
+            }
+        } else if (strcmp(arg, "file") == 0) {
+            if (value == NULL || value[0] == 0) {
+                return "file must not be empty";
+            }
+            _file = value;
+        }
+    }
+
+    return NULL;
+}

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _ARGUMENTS_H
+#define _ARGUMENTS_H
+
+
+const int DEFAULT_INTERVAL = 1000000;  // 1 ms
+const int DEFAULT_FRAMEBUF = 1000000;
+
+
+enum Action {
+    ACTION_NONE,
+    ACTION_START,
+    ACTION_STOP,
+    ACTION_STATUS,
+    ACTION_DUMP
+};
+
+class Arguments {
+  private:
+    char _buf[1024];
+    const char* _error;
+
+    const char* parse(char* args);
+
+  public:
+    int _interval;
+    int _framebuf;
+    char* _file;
+    Action _action;
+    bool _dump_flamegraph;
+    bool _dump_summary;
+    int _dump_traces;
+    int _dump_methods;
+
+    Arguments(char* args) :
+        _interval(DEFAULT_INTERVAL),
+        _framebuf(DEFAULT_FRAMEBUF),
+        _file(NULL),
+        _action(ACTION_NONE),
+        _dump_flamegraph(false),
+        _dump_summary(false),
+        _dump_traces(0),
+        _dump_methods(0) {
+        _error = parse(args);
+    }
+
+    const char* error() { return _error; }
+};
+
+#endif // _ARGUMENTS_H

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -15,13 +15,13 @@
  */
 
 #include <sstream>
+#include "arguments.h"
 #include "profiler.h"
 
 
 extern "C" JNIEXPORT void JNICALL
-Java_one_profiler_AsyncProfiler_start0(JNIEnv* env, jobject unused, jint interval, jint duration) {
-    Profiler::_instance.start(interval ? interval : DEFAULT_INTERVAL,
-                              duration ? duration : DEFAULT_DURATION);
+Java_one_profiler_AsyncProfiler_start0(JNIEnv* env, jobject unused, jint interval) {
+    Profiler::_instance.start(interval ? interval : DEFAULT_INTERVAL, DEFAULT_FRAMEBUF);
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -35,24 +35,24 @@ Java_one_profiler_AsyncProfiler_getSamples(JNIEnv* env, jobject unused) {
 }
 
 extern "C" JNIEXPORT jstring JNICALL
+Java_one_profiler_AsyncProfiler_dumpFlameGraph0(JNIEnv* env, jobject unused) {
+    std::ostringstream out;
+    Profiler::_instance.dumpFlameGraph(out);
+    return env->NewStringUTF(out.str().c_str());
+}
+
+extern "C" JNIEXPORT jstring JNICALL
 Java_one_profiler_AsyncProfiler_dumpTraces0(JNIEnv* env, jobject unused, jint max_traces) {
     std::ostringstream out;
-    Profiler::_instance.summary(out);
-    Profiler::_instance.dumpTraces(out, max_traces ? max_traces : DEFAULT_TRACES_TO_DUMP);
+    Profiler::_instance.dumpSummary(out);
+    Profiler::_instance.dumpTraces(out, max_traces ? max_traces : MAX_CALLTRACES);
     return env->NewStringUTF(out.str().c_str());
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_one_profiler_AsyncProfiler_dumpRawTraces0(JNIEnv* env, jobject unused) {
+Java_one_profiler_AsyncProfiler_dumpMethods0(JNIEnv* env, jobject unused, jint max_methods) {
     std::ostringstream out;
-    Profiler::_instance.dumpRawTraces(out);
-    return env->NewStringUTF(out.str().c_str());
-}
-
-extern "C" JNIEXPORT jstring JNICALL
-Java_one_profiler_AsyncProfiler_dumpMethods0(JNIEnv* env, jobject unused) {
-    std::ostringstream out;
-    Profiler::_instance.summary(out);
-    Profiler::_instance.dumpMethods(out);
+    Profiler::_instance.dumpSummary(out);
+    Profiler::_instance.dumpMethods(out, max_methods ? max_methods : MAX_CALLTRACES);
     return env->NewStringUTF(out.str().c_str());
 }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+#include <fstream>
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>
 #include <cxxabi.h>
-#include <sys/time.h>
 #include <sys/param.h>
 #include "profiler.h"
 #include "perfEvent.h"
@@ -104,14 +104,6 @@ class MethodName {
     }
 };
 
-
-void Profiler::frameBufferSize(int size) {
-    if (size >= 0) {
-        _frame_buffer_size = size;
-    } else {
-        std::cerr << "Ignoring frame buffer size " << size << std::endl;
-    }
-}
 
 u64 Profiler::hashCallTrace(int num_frames, ASGCT_CallFrame* frames) {
     const u64 M = 0xc6a4a7935bd1e995ULL;
@@ -209,22 +201,6 @@ void Profiler::storeMethod(jmethodID method, jint bci) {
 
     // Method found => atomically increment counter
     atomicInc(_methods[i]._counter);
-}
-
-void Profiler::checkDeadline() {
-    if (time(NULL) > _deadline) {
-        const char error[] = "Profiling duration elapsed. Disabling the "
-                             "profiler automatically is not currently "
-                             "supported. Use 'stop' explicitly.\n";
-        ssize_t w = write(STDERR_FILENO, error, sizeof(error) - 1);
-        (void) w;
-        _deadline = INT_MAX;    // Prevent further invocations
-
-        // FIXME Stopping the profiler is not safe from a signal handler. We
-        // need to refactor this to a separate thread that sleeps for the
-        // specified duration, or issue the stop command from a separate
-        // thread or after returning from the signal.
-    }
 }
 
 void Profiler::addJavaMethod(const void* address, int length, jmethodID method) {
@@ -344,8 +320,6 @@ bool Profiler::fillTopFrame(const void* pc, ASGCT_CallFrame* frame) {
 }
 
 void Profiler::recordSample(void* ucontext) {
-    checkDeadline();
-
     u64 lock_index = atomicInc(_samples) % CONCURRENCY_LEVEL;
     if (!_locks[lock_index].tryLock()) {
         atomicInc(_failures[-ticks_skipped]);  // too many concurrent signals already
@@ -383,12 +357,13 @@ void Profiler::setSignalHandler() {
     }
 }
 
-void Profiler::start(int interval, int duration) {
-    if (interval <= 0 || duration <= 0) return;
+void Profiler::start(int interval, int frame_buffer_size) {
+    if (interval <= 0) return;
 
     MutexLocker ml(_state_lock);
     if (_state != IDLE) return;
     _state = RUNNING;
+    _start_time = time(NULL);
 
     _samples = 0;
     memset(_failures, 0, sizeof(_failures));
@@ -398,16 +373,16 @@ void Profiler::start(int interval, int duration) {
 
     // Reset frames
     free(_frame_buffer);
+    _frame_buffer_size = frame_buffer_size;
     _frame_buffer = (ASGCT_CallFrame*)malloc(_frame_buffer_size * sizeof(ASGCT_CallFrame));
     _frame_buffer_index = 0;
     _frame_buffer_overflow = false;
 
     resetSymbols();
-
-    _deadline = time(NULL) + duration;
     setSignalHandler();
     
     PerfEvent::start(interval);
+    std::cout << "Profiling started with interval " << interval << " ns" << std::endl;
 }
 
 void Profiler::stop() {
@@ -416,19 +391,17 @@ void Profiler::stop() {
     _state = IDLE;
 
     PerfEvent::stop();
+    std::cout << "Profiling stopped" << std::endl;
 
     if (_frame_buffer_overflow) {
-        std::cerr << "Frame buffer overflowed with size " << _frame_buffer_size
-                << ". Consider increasing its size." << std::endl;
+        std::cerr << "Frame buffer overflowed; consider increasing its size" << std::endl;
     } else {
-        std::cout << "Frame buffer usage "
-                << _frame_buffer_index << "/" << _frame_buffer_size
-                << "="
-                << 100.0 * _frame_buffer_index / _frame_buffer_size << "%" << std::endl;
+        double usage = 100.0 * _frame_buffer_index / _frame_buffer_size;
+        std::cout << "Frame buffer usage = " << usage << "%" << std::endl;
     }
 }
 
-void Profiler::summary(std::ostream& out) {
+void Profiler::dumpSummary(std::ostream& out) {
     static const char* title[FAILURE_TYPES] = {
         "Non-Java:",
         "JVM not initialized:",
@@ -467,7 +440,7 @@ void Profiler::summary(std::ostream& out) {
  * 
  * <frame>;<frame>;...;<topmost frame> <count>
  */
-void Profiler::dumpRawTraces(std::ostream& out) {
+void Profiler::dumpFlameGraph(std::ostream& out) {
     MutexLocker ml(_state_lock);
     if (_state != IDLE) return;
 
@@ -494,9 +467,9 @@ void Profiler::dumpTraces(std::ostream& out, int max_traces) {
     qsort(_traces, MAX_CALLTRACES, sizeof(CallTraceSample), CallTraceSample::comparator);
     if (max_traces > MAX_CALLTRACES) max_traces = MAX_CALLTRACES;
 
-    for (int i = max_traces - 1; i >= 0; i--) {
+    for (int i = 0; i < max_traces; i++) {
         u64 samples = _traces[i]._counter;
-        if (samples == 0) continue;
+        if (samples == 0) break;
 
         snprintf(buf, sizeof(buf), "Samples: %lld (%.2f%%)\n", samples, samples * percent);
         out << buf;
@@ -511,7 +484,7 @@ void Profiler::dumpTraces(std::ostream& out, int max_traces) {
     }
 }
 
-void Profiler::dumpMethods(std::ostream& out) {
+void Profiler::dumpMethods(std::ostream& out, int max_methods) {
     MutexLocker ml(_state_lock);
     if (_state != IDLE) return;
 
@@ -519,13 +492,57 @@ void Profiler::dumpMethods(std::ostream& out) {
     char buf[1024];
 
     qsort(_methods, MAX_CALLTRACES, sizeof(MethodSample), MethodSample::comparator);
+    if (max_methods > MAX_CALLTRACES) max_methods = MAX_CALLTRACES;
 
-    for (int i = MAX_CALLTRACES - 1; i >= 0; i--) {
+    for (int i = 0; i < max_methods; i++) {
         u64 samples = _methods[i]._counter;
-        if (samples == 0) continue;
+        if (samples == 0) break;
 
         MethodName mn(_methods[i]._method, true);
         snprintf(buf, sizeof(buf), "%10lld (%.2f%%) %s\n", samples, samples * percent, mn.toString());
         out << buf;
+    }
+}
+
+void Profiler::dump(std::ostream& out, Arguments& args) {
+    if (args._dump_flamegraph) dumpFlameGraph(out);
+    if (args._dump_summary) dumpSummary(out);
+    if (args._dump_traces > 0) dumpTraces(out, args._dump_traces);
+    if (args._dump_methods > 0) dumpMethods(out, args._dump_methods);
+}
+
+void Profiler::run(Arguments& args) {
+    switch (args._action) {
+        case ACTION_START:
+            start(args._interval, args._framebuf);
+            break;
+        case ACTION_STOP:
+            stop();
+            break;
+        case ACTION_STATUS: {
+            MutexLocker ml(_state_lock);
+            if (_state == RUNNING) {
+                time_t sec = time(NULL) - _start_time;
+                std::cout << "Profiler is running for " << sec << " seconds" << std::endl;
+            } else {
+                std::cout << "Profiler is not active" << std::endl;
+            }
+            break;
+        }
+        case ACTION_DUMP:
+            stop();
+            if (args._file == NULL) {
+                dump(std::cout, args);
+            } else {
+                std::ofstream out(args._file, std::ios::out | std::ios::trunc);
+                if (out.is_open()) {
+                    std::cout << "Dumping profile to " << args._file << std::endl;
+                    dump(out, args);
+                    out.close();
+                } else {
+                    std::cerr << "Could not open " << args._file << std::endl;
+                }
+            }
+            break;
     }
 }

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -149,6 +149,7 @@ class Profiler {
     void storeMethod(jmethodID method, jint bci);
     void resetSymbols();
     void setSignalHandler();
+    void runInternal(Arguments& args, std::ostream& out);
 
   public:
     static Profiler _instance;
@@ -165,13 +166,13 @@ class Profiler {
         pthread_mutex_init(&_state_lock, NULL);
     }
 
-    State state() { return _state; }
-    int samples() { return _samples; }
+    State state()   { return _state; }
+    int samples()   { return _samples; }
+    time_t uptime() { return time(NULL) - _start_time; }
 
     void run(Arguments& args);
-    void start(int interval, int frame_buffer_size);
-    void stop();
-    void dump(std::ostream& out, Arguments& args);
+    bool start(int interval, int frame_buffer_size);
+    bool stop();
     void dumpSummary(std::ostream& out);
     void dumpFlameGraph(std::ostream& out);
     void dumpTraces(std::ostream& out, int max_traces);

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -12,9 +12,7 @@ FILENAME=/tmp/java.trace
 JAVAPID=$!
 
 sleep 1     # allow the Java runtime to initialize
-../profiler.sh -p $JAVAPID -a start
-sleep 5
-../profiler.sh -p $JAVAPID -a dump -f $FILENAME
+../profiler.sh -f $FILENAME -o flamegraph -d 5 $JAVAPID
 
 kill $JAVAPID
 


### PR DESCRIPTION
Here is a number of improvements both to parsing of Agent arguments and to profiler.sh command-line interface.

1. Moved arguments processing to the separate `arguments.cpp` file.
2. Removed the timeout check from the agent code (it did not work anyway). Now it is responsibility of the wrapper script to stop the profiling after the specified period of time.
3. Added `-d` (duration) option to profiler.sh. It allows to execute start-wait-stop sequence with just one command.
4. Allowed to dump any combination of profiling data (summary / flat profile / call stacks / flamegraph) also with just one command.
5. Filename option now works not only for the flamegraph format, but for any combination of output formats above.
6. Added --status option to print whether profiler is active and for how long.